### PR TITLE
BME280 fix

### DIFF
--- a/MainUI/App.xaml.cs
+++ b/MainUI/App.xaml.cs
@@ -143,7 +143,7 @@ namespace HypoxiaChamber
             await SetUpFile();
             App.SensorProvider.MHZ16.Initialize();        //Initialize CO2 Sensor
             await App.SensorProvider.mcp3008.Initialize();  //Initialize ADC (for O2 Sensor Voltage Reading)
-            //await App.SensorProvider.BME280.Initialize();   //Initialize Environmental Sensor
+            await App.SensorProvider.BME280.Initialize();   //Initialize Environmental Sensor
             //SensorProvider.StartTimer();                    //Start Timer that triggers sensor readings
             try
             {

--- a/MainUI/Sensors/BME280.cs
+++ b/MainUI/Sensors/BME280.cs
@@ -1,11 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Windows.Devices.Enumeration;
-using Windows.Devices.Gpio;
 using Windows.Devices.I2c;
 
 namespace HypoxiaChamber
@@ -123,7 +119,7 @@ namespace HypoxiaChamber
                 //Check if device was found
                 if (bme280 == null)
                 {
-                    Debug.WriteLine("Device not found");
+                    Debug.WriteLine("BME280::Device not found");
                 }
                 else
                 {

--- a/MainUI/Sensors/BME280.cs
+++ b/MainUI/Sensors/BME280.cs
@@ -106,7 +106,7 @@ namespace HypoxiaChamber
         //Method to initialize the BME280 sensor
         public async Task Initialize()
         {
-            Debug.WriteLine("BME280::Initialize");
+            Debug.WriteLine("BME280::Initialize Attempt");
 
             try
             {
@@ -135,13 +135,13 @@ namespace HypoxiaChamber
                     catch (Exception e)
                     {
                         init = false;
-                        Debug.WriteLine("Exception: " + e.Message + "\n" + e.StackTrace);
+                        Debug.WriteLine("BME280::Initialization Exception: " + e.Message + "\n" + e.StackTrace);
                     }
                 }
             }
             catch (Exception e)
             {
-                Debug.WriteLine("Exception: " + e.Message + "\n" + e.StackTrace);
+                Debug.WriteLine("BME280::Exception: " + e.Message + "\n" + e.StackTrace);
                 throw;
             }
 
@@ -154,7 +154,7 @@ namespace HypoxiaChamber
 
             //Read the device signature
             bme280.WriteRead(WriteBuffer, ReadBuffer);
-            Debug.WriteLine("BME280 Signature: " + ReadBuffer[0].ToString());
+            Debug.WriteLine("BME280::Signature: " + ReadBuffer[0].ToString());
 
             //Verify the device signature
             if (ReadBuffer[0] != BME280_Signature)

--- a/MainUI/Sensors/SensorControl.cs
+++ b/MainUI/Sensors/SensorControl.cs
@@ -35,7 +35,7 @@ namespace HypoxiaChamber
         public SensorDataProvider()
         {
             mcp3008 = new MCP3008(ReferenceVoltage);
-            //BME280 = new BME280();
+            BME280 = new BME280();
             MHZ16 = new MHZ16();
             //StartTimer();
         }
@@ -85,6 +85,7 @@ namespace HypoxiaChamber
             if (BME280 == null)
             {
                 Debug.WriteLine("BME280 is null");
+                return;
             }
             else
             {


### PR DESCRIPTION
Ready to reintegrate into the master. Problem solved. Be sure BME hardware is hooked up appropriately for the I2C usage, NOT for SPI.

See appropriate hookup here: [https://learn.adafruit.com/adafruit-bme280-humidity-barometric-pressure-temperature-sensor-breakout/pinouts](url)